### PR TITLE
change module name prefix (follow-up for LUCENE-10234)

### DIFF
--- a/lucene/analysis/common/src/java-module/module-info.java
+++ b/lucene/analysis/common/src/java-module/module-info.java
@@ -16,9 +16,9 @@
  */
 
 /** Lucene Analysis Common. */
-module lucene.analysis.common {
+module org.apache.lucene.analysis.common {
   requires java.xml;
-  requires lucene.core;
+  requires org.apache.lucene.core;
 
   exports org.apache.lucene.analysis.ar;
   exports org.apache.lucene.analysis.bg;
@@ -91,7 +91,6 @@ module lucene.analysis.common {
       org.apache.lucene.analysis.cjk.CJKWidthCharFilterFactory,
       org.apache.lucene.analysis.fa.PersianCharFilterFactory,
       org.apache.lucene.analysis.pattern.PatternReplaceCharFilterFactory;
-
   provides org.apache.lucene.analysis.TokenFilterFactory with
       org.apache.lucene.analysis.tr.ApostropheFilterFactory,
       org.apache.lucene.analysis.ar.ArabicNormalizationFilterFactory,
@@ -201,7 +200,6 @@ module lucene.analysis.common {
       org.apache.lucene.analysis.te.TeluguStemFilterFactory,
       org.apache.lucene.analysis.tr.TurkishLowerCaseFilterFactory,
       org.apache.lucene.analysis.util.ElisionFilterFactory;
-
   provides org.apache.lucene.analysis.TokenizerFactory with
       org.apache.lucene.analysis.classic.ClassicTokenizerFactory,
       org.apache.lucene.analysis.core.KeywordTokenizerFactory,
@@ -216,5 +214,4 @@ module lucene.analysis.common {
       org.apache.lucene.analysis.pattern.SimplePatternTokenizerFactory,
       org.apache.lucene.analysis.th.ThaiTokenizerFactory,
       org.apache.lucene.analysis.wikipedia.WikipediaTokenizerFactory;
-
 }

--- a/lucene/core/src/java-module/module-info.java
+++ b/lucene/core/src/java-module/module-info.java
@@ -16,7 +16,7 @@
  */
 
 /** Lucene Core. */
-module lucene.core {
+module org.apache.lucene.core {
   exports org.apache.lucene.analysis;
   exports org.apache.lucene.analysis.standard;
   exports org.apache.lucene.analysis.tokenattributes;

--- a/lucene/luke/build.gradle
+++ b/lucene/luke/build.gradle
@@ -116,7 +116,7 @@ task standaloneAssemble(type: Sync) {
         """
 Standalone Luke distribution assembled. You can run it with:
 java -jar "${standaloneDistDir}/${standaloneJar.archiveFileName.get()}"
-java --module-path "${standaloneDistDir}" -m lucene.luke
+java --module-path "${standaloneDistDir}" -m org.apache.lucene.luke
         """
     )
   }

--- a/lucene/luke/src/java-module/module-info.java
+++ b/lucene/luke/src/java-module/module-info.java
@@ -17,11 +17,11 @@
 
 /** Luke : Lucene toolbox project. */
 @SuppressWarnings({"requires-automatic"})
-module lucene.luke {
+module org.apache.lucene.luke {
   requires java.desktop;
   requires java.logging;
-  requires lucene.core;
-  requires lucene.analysis.common;
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.analysis.common;
   requires org.apache.logging.log4j;
   requires org.apache.logging.log4j.core;
 }


### PR DESCRIPTION
Add the same prefix as the automatic module name.
https://github.com/apache/lucene/commit/20cb6817db45d261bf336102f5842674f377d823

Luke works well for me. Is the change correct?  @dweiss @uschindler