### PR TITLE
Add a utility task to list all existing pacage names

### DIFF
--- a/gradle/java/modules.gradle
+++ b/gradle/java/modules.gradle
@@ -1,4 +1,5 @@
 import java.util.jar.JarFile
+import java.util.stream.Collectors
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -67,10 +68,11 @@ allprojects {
       doFirst {
         var pkgNameSet = [] as Set<String>
         sourceSets.main.each { sourceSet ->
-          var dirs = sourceSet.allJava.srcDirTrees.collect { it.dir.path.toString() }
+          var dirs = sourceSet.allJava.srcDirTrees.collect { it.dir.toPath() }
           sourceSet.allJava.filter{ it.name != "module-info.java" && it.name != "package-info.java" }.each {srcFile ->
-            var dir = dirs.findAll { srcFile.path.matches("^${it}/.*\$") }.get(0)
-            var pkgName = srcFile.path.replaceFirst("${dir}/", "").replaceFirst("/${srcFile.name}\$", "").replace("/", ".")
+            var srcPath = srcFile.toPath()
+            var dir = dirs.find { srcPath.startsWith(it) }
+            var pkgName = srcPath.subpath(dir.nameCount, srcPath.nameCount).parent.stream().map(Object::toString).collect(Collectors.joining('.'))
             pkgNameSet.add(pkgName)
           }
         }

--- a/gradle/java/modules.gradle
+++ b/gradle/java/modules.gradle
@@ -58,3 +58,27 @@ configure(rootProject) {
     }
   })
 }
+
+allprojects {
+  // Show all non-empty package names
+  // There should be a better way...
+  plugins.withType(JavaPlugin) {
+    tasks.register("showPackageNames", { task ->
+      doFirst {
+        var pkgNameSet = [] as Set<String>
+        sourceSets.main.each { sourceSet ->
+          var dirs = sourceSet.allJava.srcDirTrees.collect { it.dir.path.toString() }
+          sourceSet.allJava.filter{ it.name != "module-info.java" && it.name != "package-info.java" }.each {srcFile ->
+            var dir = dirs.findAll { srcFile.path.matches("^${it}/.*\$") }.get(0)
+            var pkgName = srcFile.path.replaceFirst("${dir}/", "").replaceFirst("/${srcFile.name}\$", "").replace("/", ".")
+            pkgNameSet.add(pkgName)
+          }
+        }
+        var pkgNames = pkgNameSet as List<String>
+        pkgNames.sort()
+        pkgNames.each { println(it) }
+      }
+    })
+  }
+}
+


### PR DESCRIPTION
This task shows the existing package names.

```
lucene $ ./gradlew -p lucene/analysis/common/ showPackageNames

> Task :lucene:analysis:common:showPackageNames
org.apache.lucene.analysis.ar
org.apache.lucene.analysis.bg
org.apache.lucene.analysis.bn
org.apache.lucene.analysis.boost
org.apache.lucene.analysis.br
org.apache.lucene.analysis.ca
org.apache.lucene.analysis.charfilter
org.apache.lucene.analysis.cjk
org.apache.lucene.analysis.ckb
org.apache.lucene.analysis.classic
org.apache.lucene.analysis.commongrams
org.apache.lucene.analysis.compound
org.apache.lucene.analysis.compound.hyphenation
org.apache.lucene.analysis.core
org.apache.lucene.analysis.custom
org.apache.lucene.analysis.cz
org.apache.lucene.analysis.da
org.apache.lucene.analysis.de
org.apache.lucene.analysis.el
org.apache.lucene.analysis.email
org.apache.lucene.analysis.en
org.apache.lucene.analysis.es
org.apache.lucene.analysis.et
org.apache.lucene.analysis.eu
org.apache.lucene.analysis.fa
org.apache.lucene.analysis.fi
org.apache.lucene.analysis.fr
org.apache.lucene.analysis.ga
org.apache.lucene.analysis.gl
org.apache.lucene.analysis.hi
org.apache.lucene.analysis.hu
org.apache.lucene.analysis.hunspell
org.apache.lucene.analysis.hy
org.apache.lucene.analysis.id
org.apache.lucene.analysis.in
org.apache.lucene.analysis.it
org.apache.lucene.analysis.lt
org.apache.lucene.analysis.lv
org.apache.lucene.analysis.minhash
org.apache.lucene.analysis.miscellaneous
org.apache.lucene.analysis.ne
org.apache.lucene.analysis.ngram
org.apache.lucene.analysis.nl
org.apache.lucene.analysis.no
org.apache.lucene.analysis.path
org.apache.lucene.analysis.pattern
org.apache.lucene.analysis.payloads
org.apache.lucene.analysis.pt
org.apache.lucene.analysis.query
org.apache.lucene.analysis.reverse
org.apache.lucene.analysis.ro
org.apache.lucene.analysis.ru
org.apache.lucene.analysis.shingle
org.apache.lucene.analysis.sinks
org.apache.lucene.analysis.snowball
org.apache.lucene.analysis.sr
org.apache.lucene.analysis.sv
org.apache.lucene.analysis.synonym
org.apache.lucene.analysis.ta
org.apache.lucene.analysis.te
org.apache.lucene.analysis.th
org.apache.lucene.analysis.tr
org.apache.lucene.analysis.util
org.apache.lucene.analysis.wikipedia
org.apache.lucene.collation
org.apache.lucene.collation.tokenattributes
org.tartarus.snowball
org.tartarus.snowball.ext
```
