### PR TITLE
Add a task to generate scaffold module-info.java

### DIFF
--- a/gradle/java/modules.gradle
+++ b/gradle/java/modules.gradle
@@ -62,25 +62,53 @@ configure(rootProject) {
 
 allprojects {
   // Show all non-empty package names
-  // There should be a better way...
   plugins.withType(JavaPlugin) {
     tasks.register("showPackageNames", { task ->
       doFirst {
-        var pkgNameSet = [] as Set<String>
-        sourceSets.main.each { sourceSet ->
-          var dirs = sourceSet.allJava.srcDirTrees.collect { it.dir.toPath() }
-          sourceSet.allJava.filter{ it.name != "module-info.java" && it.name != "package-info.java" }.each {srcFile ->
-            var srcPath = srcFile.toPath()
-            var dir = dirs.find { srcPath.startsWith(it) }
-            var pkgName = srcPath.subpath(dir.nameCount, srcPath.nameCount).parent.stream().map(Object::toString).collect(Collectors.joining('.'))
-            pkgNameSet.add(pkgName)
-          }
-        }
-        var pkgNames = pkgNameSet as List<String>
-        pkgNames.sort()
-        pkgNames.each { println(it) }
+        listPackageNames(sourceSets).each { println(it) }
       }
     })
   }
+}
+
+allprojects {
+  plugins.withType(JavaPlugin) {
+    tasks.register("scaffoldModuleDescriptor", {
+      doFirst {
+        def moduleName = "org.apache" + project.path.replace('-', '_').replace(':', '.')
+        def pkgNames = listPackageNames(sourceSets)
+        def outFile = project.file("${getTemporaryDir()}/module-info.java")
+        outFile.withWriter("UTF-8", { writer ->
+          writer.write("module ${moduleName} {\n")
+          pkgNames.each {pkg ->
+            writer.write("  exports ")
+            writer.write(pkg)
+            writer.write(";\n")
+          }
+          writer.write("}\n")
+        })
+
+        logger.lifecycle("Output to: ${outFile}")
+        logger.lifecycle("NOTE: The generated module descriptor is not complete and won't work as is.")
+      }
+    })
+  }
+}
+
+/* Utility method to collect all package names in a source sets. */
+static def listPackageNames(SourceSetContainer sourceSets) {
+  var pkgNameSet = [] as Set<String>
+  sourceSets.main.each { sourceSet ->
+    var dirs = sourceSet.allJava.srcDirTrees.collect { it.dir.toPath() }
+    sourceSet.allJava.filter{ it.name != "module-info.java" && it.name != "package-info.java" }.each {srcFile ->
+      var srcPath = srcFile.toPath()
+      var dir = dirs.find { srcPath.startsWith(it) }
+      var pkgName = srcPath.subpath(dir.nameCount, srcPath.nameCount).parent.stream().map(Object::toString).collect(Collectors.joining('.'))
+      pkgNameSet.add(pkgName)
+    }
+  }
+  var pkgNames = pkgNameSet as List<String>
+  pkgNames.sort()
+  return pkgNames
 }
 


### PR DESCRIPTION
This adds another utility task to generate skeleton module descriptors.

```
lucene $ ./gradlew -p lucene/backward-codecs/ scaffoldModuleDescriptor

> Task :lucene:backward-codecs:scaffoldModuleDescriptor
Output to: /mnt/hdd/repo/lucene/lucene/backward-codecs/build/tmp/scaffoldModuleDescriptor/module-info.java
NOTE: The generated module descriptor is not complete and won't work as is.
```

```
lucene $ less lucene/backward-codecs/build/tmp/scaffoldModuleDescriptor/module-info.java 
module org.apache.lucene.backward_codecs {
  exports org.apache.lucene.backward_codecs;
  exports org.apache.lucene.backward_codecs.lucene40.blocktree;
  exports org.apache.lucene.backward_codecs.lucene50;
  exports org.apache.lucene.backward_codecs.lucene50.compressing;
  exports org.apache.lucene.backward_codecs.lucene60;
  exports org.apache.lucene.backward_codecs.lucene70;
  exports org.apache.lucene.backward_codecs.lucene80;
  exports org.apache.lucene.backward_codecs.lucene84;
  exports org.apache.lucene.backward_codecs.lucene86;
  exports org.apache.lucene.backward_codecs.lucene87;
  exports org.apache.lucene.backward_codecs.packed;
  exports org.apache.lucene.backward_codecs.store;
}
```