### PR TITLE
Add provides and uses statements to scaffold module-info

### DIFF
--- a/gradle/java/modules.gradle
+++ b/gradle/java/modules.gradle
@@ -72,18 +72,51 @@ allprojects {
 }
 
 allprojects {
+  // Show all service providers
+  plugins.withType(JavaPlugin) {
+    tasks.register("showServiceProviders", { task ->
+      doFirst {
+        def services = listServices(sourceSets)
+        services.each { entry -> {
+          println(entry.key)
+          entry.value.each { println("  ${it}") }
+        }}
+      }
+    })
+  }
+}
+
+allprojects {
   plugins.withType(JavaPlugin) {
     tasks.register("scaffoldModuleDescriptor", {
       doFirst {
         def moduleName = "org.apache" + project.path.replace('-', '_').replace(':', '.')
         def pkgNames = listPackageNames(sourceSets)
+        def services = listServices(sourceSets)
         def outFile = project.file("${getTemporaryDir()}/module-info.java")
         outFile.withWriter("UTF-8", { writer ->
           writer.write("module ${moduleName} {\n")
+          // write exports statements
           pkgNames.each {pkg ->
             writer.write("  exports ")
             writer.write(pkg)
             writer.write(";\n")
+          }
+          writer.write("\n")
+          // write provides statements
+          services.each { entry -> {
+            def service = entry.key
+            def providers = "      " + entry.value.join(",\n      ")
+            writer.write("  provides ")
+            writer.write(service)
+            writer.write(" with\n")
+            writer.write(providers)
+            writer.write(";\n")
+          }}
+          writer.write("\n")
+          // write uses statements
+          services.keySet().each { service ->
+            writer.write("  uses ${service};\n")
           }
           writer.write("}\n")
         })
@@ -110,5 +143,27 @@ static def listPackageNames(SourceSetContainer sourceSets) {
   var pkgNames = pkgNameSet as List<String>
   pkgNames.sort()
   return pkgNames
+}
+
+/* Utility method to collect all service providers in a source sets. */
+static def listServices(SourceSetContainer sourceSets) {
+  def services = [:] as Map<String, List<String>>
+  sourceSets.main.each {sourceSet ->
+    sourceSet.resources.filter { file -> file.path.contains("META-INF/services/") }.each {file ->
+      def serviceName = file.name
+      def providers = []
+      file.withReader { reader -> {
+        reader.lines().each { l ->
+          def line = l.trim()
+          if (line != "" && !line.startsWith("#")) {
+            def provider = line.replace('$', '.')
+            providers.add(provider)
+          }
+        }
+      }}
+      services.put(serviceName, providers)
+    }
+  }
+  return services
 }
 


### PR DESCRIPTION
Follow-up of https://github.com/dweiss/lucene/pull/4

```
lucene $ ./gradlew -p lucene/core/ scaffoldModuleDescriptor

> Task :lucene:core:scaffoldModuleDescriptor
Output to: /mnt/hdd/repo/lucene/lucene/core/build/tmp/scaffoldModuleDescriptor/module-info.java
NOTE: The generated module descriptor is not complete and won't work as is.

lucene $ less /mnt/hdd/repo/lucene/lucene/core/build/tmp/scaffoldModuleDescriptor/module-info.java
module org.apache.lucene.core {
  exports org.apache.lucene.analysis;
  exports org.apache.lucene.analysis.standard;
  exports org.apache.lucene.analysis.tokenattributes;
  exports org.apache.lucene.codecs;
  exports org.apache.lucene.codecs.compressing;
  exports org.apache.lucene.codecs.lucene90;
  exports org.apache.lucene.codecs.lucene90.blocktree;
  exports org.apache.lucene.codecs.lucene90.compressing;
  exports org.apache.lucene.codecs.perfield;
  exports org.apache.lucene.document;
  exports org.apache.lucene.geo;
  exports org.apache.lucene.index;
  exports org.apache.lucene.search;
  exports org.apache.lucene.search.comparators;
  exports org.apache.lucene.search.similarities;
  exports org.apache.lucene.store;
  exports org.apache.lucene.util;
  exports org.apache.lucene.util.automaton;
  exports org.apache.lucene.util.bkd;
  exports org.apache.lucene.util.compress;
  exports org.apache.lucene.util.fst;
  exports org.apache.lucene.util.graph;
  exports org.apache.lucene.util.hnsw;
  exports org.apache.lucene.util.hppc;
  exports org.apache.lucene.util.mutable;
  exports org.apache.lucene.util.packed;

  provides org.apache.lucene.codecs.DocValuesFormat with
      org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
  provides org.apache.lucene.codecs.PostingsFormat with
      org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat;
  provides org.apache.lucene.analysis.TokenizerFactory with
      org.apache.lucene.analysis.standard.StandardTokenizerFactory;
  provides org.apache.lucene.index.SortFieldProvider with
      org.apache.lucene.search.SortField.Provider,
      org.apache.lucene.search.SortedNumericSortField.Provider,
      org.apache.lucene.search.SortedSetSortField.Provider;
  provides org.apache.lucene.codecs.Codec with
      org.apache.lucene.codecs.lucene90.Lucene90Codec;
  provides org.apache.lucene.codecs.KnnVectorsFormat with
      org.apache.lucene.codecs.lucene90.Lucene90HnswVectorsFormat;

  uses org.apache.lucene.codecs.DocValuesFormat;
  uses org.apache.lucene.codecs.PostingsFormat;
  uses org.apache.lucene.analysis.TokenizerFactory;
  uses org.apache.lucene.index.SortFieldProvider;
  uses org.apache.lucene.codecs.Codec;
  uses org.apache.lucene.codecs.KnnVectorsFormat;
}
```

Note: Services that have no implementations won't be shown.