### PR TITLE
Add module-info to analysis modules

### DIFF
--- a/lucene/analysis/icu/src/java-module/module-info.java
+++ b/lucene/analysis/icu/src/java-module/module-info.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Analysis integration with ICU */
+@SuppressWarnings({"requires-automatic"})
+module org.apache.lucene.analysis.icu {
+  requires com.ibm.icu;
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.analysis.common;
+
+  exports org.apache.lucene.analysis.icu;
+  exports org.apache.lucene.analysis.icu.segmentation;
+  exports org.apache.lucene.analysis.icu.tokenattributes;
+
+  provides org.apache.lucene.analysis.CharFilterFactory with
+      org.apache.lucene.analysis.icu.ICUNormalizer2CharFilterFactory;
+  provides org.apache.lucene.analysis.TokenizerFactory with
+      org.apache.lucene.analysis.icu.segmentation.ICUTokenizerFactory;
+  provides org.apache.lucene.analysis.TokenFilterFactory with
+      org.apache.lucene.analysis.icu.ICUFoldingFilterFactory,
+      org.apache.lucene.analysis.icu.ICUNormalizer2FilterFactory,
+      org.apache.lucene.analysis.icu.ICUTransformFilterFactory;
+}

--- a/lucene/analysis/kuromoji/src/java-module/module-info.java
+++ b/lucene/analysis/kuromoji/src/java-module/module-info.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Japanese Morphological Analyzer */
+module org.apache.lucene.analysis.kuromoji {
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.analysis.common;
+
+  exports org.apache.lucene.analysis.ja;
+  exports org.apache.lucene.analysis.ja.completion;
+  exports org.apache.lucene.analysis.ja.dict;
+  exports org.apache.lucene.analysis.ja.tokenattributes;
+  exports org.apache.lucene.analysis.ja.util;
+
+  provides org.apache.lucene.analysis.CharFilterFactory with
+      org.apache.lucene.analysis.ja.JapaneseIterationMarkCharFilterFactory;
+  provides org.apache.lucene.analysis.TokenizerFactory with
+      org.apache.lucene.analysis.ja.JapaneseTokenizerFactory;
+  provides org.apache.lucene.analysis.TokenFilterFactory with
+      org.apache.lucene.analysis.ja.JapaneseBaseFormFilterFactory,
+      org.apache.lucene.analysis.ja.JapaneseCompletionFilterFactory,
+      org.apache.lucene.analysis.ja.JapaneseKatakanaStemFilterFactory,
+      org.apache.lucene.analysis.ja.JapaneseNumberFilterFactory,
+      org.apache.lucene.analysis.ja.JapanesePartOfSpeechStopFilterFactory,
+      org.apache.lucene.analysis.ja.JapaneseReadingFormFilterFactory;
+}

--- a/lucene/analysis/morfologik/src/java-module/_module-info.java
+++ b/lucene/analysis/morfologik/src/java-module/_module-info.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Analyzer for dictionary stemming, built-in Polish dictionary */
+// @SuppressWarnings({"requires-automatic"})
+/*
+module org.apache.lucene.analysis.morfologik {
+  requires morfologik.stemming;
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.analysis.common;
+
+  exports org.apache.lucene.analysis.morfologik;
+  exports org.apache.lucene.analysis.uk;
+
+  provides org.apache.lucene.analysis.TokenFilterFactory with
+      org.apache.lucene.analysis.morfologik.MorfologikFilterFactory;
+}
+*/

--- a/lucene/analysis/nori/src/java-module/module-info.java
+++ b/lucene/analysis/nori/src/java-module/module-info.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Korean Morphological Analyzer */
+module org.apache.lucene.analysis.nori {
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.analysis.common;
+
+  exports org.apache.lucene.analysis.ko;
+  exports org.apache.lucene.analysis.ko.dict;
+  exports org.apache.lucene.analysis.ko.tokenattributes;
+  exports org.apache.lucene.analysis.ko.util;
+
+  provides org.apache.lucene.analysis.TokenizerFactory with
+      org.apache.lucene.analysis.ko.KoreanTokenizerFactory;
+  provides org.apache.lucene.analysis.TokenFilterFactory with
+      org.apache.lucene.analysis.ko.KoreanPartOfSpeechStopFilterFactory,
+      org.apache.lucene.analysis.ko.KoreanReadingFormFilterFactory;
+}

--- a/lucene/analysis/opennlp/src/java-module/module-info.java
+++ b/lucene/analysis/opennlp/src/java-module/module-info.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** OpenNLP Library Integration */
+@SuppressWarnings({"requires-automatic"})
+module org.apache.lucene.analysis.opennlp {
+  requires org.apache.opennlp.tools;
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.analysis.common;
+
+  exports org.apache.lucene.analysis.opennlp;
+  exports org.apache.lucene.analysis.opennlp.tools;
+
+  provides org.apache.lucene.analysis.TokenizerFactory with
+      org.apache.lucene.analysis.opennlp.OpenNLPTokenizerFactory;
+  provides org.apache.lucene.analysis.TokenFilterFactory with
+      org.apache.lucene.analysis.opennlp.OpenNLPChunkerFilterFactory,
+      org.apache.lucene.analysis.opennlp.OpenNLPLemmatizerFilterFactory,
+      org.apache.lucene.analysis.opennlp.OpenNLPPOSFilterFactory;
+}

--- a/lucene/analysis/phonetic/src/java-module/module-info.java
+++ b/lucene/analysis/phonetic/src/java-module/module-info.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Analyzer for indexing phonetic signatures */
+@SuppressWarnings({"requires-automatic"})
+module org.apache.lucene.analysis.phonetic {
+  requires org.apache.commons.codec;
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.analysis.common;
+
+  exports org.apache.lucene.analysis.phonetic;
+
+  provides org.apache.lucene.analysis.TokenFilterFactory with
+      org.apache.lucene.analysis.phonetic.BeiderMorseFilterFactory,
+      org.apache.lucene.analysis.phonetic.DoubleMetaphoneFilterFactory,
+      org.apache.lucene.analysis.phonetic.PhoneticFilterFactory;
+}

--- a/lucene/analysis/smartcn/src/java-module/module-info.java
+++ b/lucene/analysis/smartcn/src/java-module/module-info.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Analyzer for indexing Chinese */
+module org.apache.lucene.analysis.smartcn {
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.analysis.common;
+
+  exports org.apache.lucene.analysis.cn.smart;
+  exports org.apache.lucene.analysis.cn.smart.hhmm;
+
+  provides org.apache.lucene.analysis.TokenizerFactory with
+      org.apache.lucene.analysis.cn.smart.HMMChineseTokenizerFactory;
+}

--- a/lucene/analysis/stempel/src/java-module/module-info.java
+++ b/lucene/analysis/stempel/src/java-module/module-info.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Analyzer for indexing Polish */
+module org.apache.lucene.analysis.stempel {
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.analysis.common;
+
+  exports org.apache.lucene.analysis.pl;
+  exports org.apache.lucene.analysis.stempel;
+  exports org.egothor.stemmer;
+
+  provides org.apache.lucene.analysis.TokenFilterFactory with
+      org.apache.lucene.analysis.stempel.StempelPolishStemFilterFactory;
+}


### PR DESCRIPTION
This adds module-info.java to the following subprojects (all analysis modules).

- analysis/icu
- analysis/kuromoji
- analysis/morfologik (disabled; see the description below)
- analysis/nori
- analysis/opennlp
- analysis/phonetic
- analysis/smartcn
- analysis/stempel

An error happens when compiling `morfologik` module; I was not able to solve the problem.
```
lucene $ ./gradlew -p lucene/analysis/morfologik/ jar -Duser.language=en
Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details

> Task :errorProneSkipped
WARNING: errorprone disabled (skipped on non-nightly runs)

> Task :lucene:analysis:morfologik:compileJava FAILED
/mnt/hdd/repo/lucene/lucene/analysis/morfologik/src/java-module/module-info.java:21: error: module not found: morfologik.stemming
  requires morfologik.stemming;
                     ^
1 error
```

This passes `distribution-test`.
```
lucene $ ./gradlew -p lucene/distribution-tests/ test

> Task :randomizationInfo
Running tests with randomization seed: tests.seed=1A3480CBB8312791

> Task :errorProneSkipped
WARNING: errorprone disabled (skipped on non-nightly runs)

> Task :lucene:distribution-tests:test
:lucene:distribution-tests:test (SUCCESS): 3 test(s)

BUILD SUCCESSFUL in 2s
```

(Also, Luke successfully load the service providers in the modules above.)