### PR TITLE
Add module descriptors to java projects

### DIFF
--- a/lucene/backward-codecs/src/java-module/module-info.java
+++ b/lucene/backward-codecs/src/java-module/module-info.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Codecs for older versions of Lucene */
+module org.apache.lucene.backward_codecs {
+  requires org.apache.lucene.core;
+
+  exports org.apache.lucene.backward_codecs;
+  exports org.apache.lucene.backward_codecs.lucene40.blocktree;
+  exports org.apache.lucene.backward_codecs.lucene50;
+  exports org.apache.lucene.backward_codecs.lucene50.compressing;
+  exports org.apache.lucene.backward_codecs.lucene60;
+  exports org.apache.lucene.backward_codecs.lucene70;
+  exports org.apache.lucene.backward_codecs.lucene80;
+  exports org.apache.lucene.backward_codecs.lucene84;
+  exports org.apache.lucene.backward_codecs.lucene86;
+  exports org.apache.lucene.backward_codecs.lucene87;
+  exports org.apache.lucene.backward_codecs.packed;
+  exports org.apache.lucene.backward_codecs.store;
+
+  provides org.apache.lucene.codecs.DocValuesFormat with
+      org.apache.lucene.backward_codecs.lucene80.Lucene80DocValuesFormat;
+  provides org.apache.lucene.codecs.PostingsFormat with
+      org.apache.lucene.backward_codecs.lucene50.Lucene50PostingsFormat,
+      org.apache.lucene.backward_codecs.lucene84.Lucene84PostingsFormat;
+  provides org.apache.lucene.codecs.Codec with
+      org.apache.lucene.backward_codecs.lucene80.Lucene80Codec,
+      org.apache.lucene.backward_codecs.lucene84.Lucene84Codec,
+      org.apache.lucene.backward_codecs.lucene86.Lucene86Codec,
+      org.apache.lucene.backward_codecs.lucene87.Lucene87Codec;
+}

--- a/lucene/classification/src/java-module/module-info.java
+++ b/lucene/classification/src/java-module/module-info.java
@@ -15,16 +15,13 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Classification module for Lucene */
+module org.apache.lucene.classification {
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
   requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+  requires org.apache.lucene.grouping;
+
+  exports org.apache.lucene.classification;
+  exports org.apache.lucene.classification.document;
+  exports org.apache.lucene.classification.utils;
 }

--- a/lucene/codecs/src/java-module/module-info.java
+++ b/lucene/codecs/src/java-module/module-info.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Lucene codecs and postings formats */
+module org.apache.lucene.codecs {
+  requires org.apache.lucene.core;
+
+  exports org.apache.lucene.codecs.blockterms;
+  exports org.apache.lucene.codecs.blocktreeords;
+  exports org.apache.lucene.codecs.bloom;
+  exports org.apache.lucene.codecs.memory;
+  exports org.apache.lucene.codecs.simpletext;
+  exports org.apache.lucene.codecs.uniformsplit;
+  exports org.apache.lucene.codecs.uniformsplit.sharedterms;
+
+  provides org.apache.lucene.codecs.PostingsFormat with
+      org.apache.lucene.codecs.blocktreeords.BlockTreeOrdsPostingsFormat,
+      org.apache.lucene.codecs.bloom.BloomFilteringPostingsFormat,
+      org.apache.lucene.codecs.memory.DirectPostingsFormat,
+      org.apache.lucene.codecs.memory.FSTPostingsFormat,
+      org.apache.lucene.codecs.uniformsplit.UniformSplitPostingsFormat,
+      org.apache.lucene.codecs.uniformsplit.sharedterms.STUniformSplitPostingsFormat;
+  provides org.apache.lucene.codecs.Codec with
+      org.apache.lucene.codecs.simpletext.SimpleTextCodec;
+}

--- a/lucene/demo/src/java-module/module-info.java
+++ b/lucene/demo/src/java-module/module-info.java
@@ -15,16 +15,20 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
+/** Simple example code for Apache Lucene */
+// TODO: The compiler complains about "requires-automatic" since "expressions" module is an
+// automatic module for now.
+// Once that is properly modularized, this line can be removed.
 @SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+module org.apache.lucene.demo {
   requires org.apache.lucene.core;
   requires org.apache.lucene.analysis.common;
+  requires org.apache.lucene.facet;
   requires org.apache.lucene.queries;
   requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+  requires org.apache.lucene.expressions;
+
+  exports org.apache.lucene.demo;
+  exports org.apache.lucene.demo.facet;
+  exports org.apache.lucene.demo.knn;
 }

--- a/lucene/expressions/src/java-module/_module-info.java
+++ b/lucene/expressions/src/java-module/_module-info.java
@@ -15,16 +15,17 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+// @SuppressWarnings({"requires-automatic"})
+/*
+module org.apache.lucene.expressions {
+  requires org.objectweb.asm;
+  requires org.objectweb.asm.commons;
+  requires antlr4.runtime;
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
-  requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+  requires org.apache.lucene.codecs;
+
+  exports org.apache.lucene.expressions;
+  exports org.apache.lucene.expressions.js;
+
 }
+*/

--- a/lucene/facet/src/java-module/module-info.java
+++ b/lucene/facet/src/java-module/module-info.java
@@ -15,16 +15,17 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
+/** Faceted indexing and search capabilities */
 @SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
+module org.apache.lucene.facet {
   requires java.logging;
+  requires com.carrotsearch.hppc;
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
-  requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+
+  exports org.apache.lucene.facet;
+  exports org.apache.lucene.facet.range;
+  exports org.apache.lucene.facet.sortedset;
+  exports org.apache.lucene.facet.taxonomy;
+  exports org.apache.lucene.facet.taxonomy.directory;
+  exports org.apache.lucene.facet.taxonomy.writercache;
 }

--- a/lucene/grouping/src/java-module/module-info.java
+++ b/lucene/grouping/src/java-module/module-info.java
@@ -15,16 +15,10 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Collectors for grouping search results */
+module org.apache.lucene.grouping {
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
   requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+
+  exports org.apache.lucene.search.grouping;
 }

--- a/lucene/highlighter/src/java-module/module-info.java
+++ b/lucene/highlighter/src/java-module/module-info.java
@@ -15,16 +15,14 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Highlights search keywords in results */
+module org.apache.lucene.highlighter {
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
   requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+  requires org.apache.lucene.memory;
+
+  exports org.apache.lucene.search.highlight;
+  exports org.apache.lucene.search.matchhighlight;
+  exports org.apache.lucene.search.uhighlight;
+  exports org.apache.lucene.search.vectorhighlight;
 }

--- a/lucene/join/src/java-module/module-info.java
+++ b/lucene/join/src/java-module/module-info.java
@@ -15,16 +15,9 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Index-time and Query-time joins for normalized content */
+module org.apache.lucene.join {
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
-  requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+
+  exports org.apache.lucene.search.join;
 }

--- a/lucene/memory/src/java-module/module-info.java
+++ b/lucene/memory/src/java-module/module-info.java
@@ -15,16 +15,9 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Single-document in-memory index implementation */
+module org.apache.lucene.memory {
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
-  requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+
+  exports org.apache.lucene.index.memory;
 }

--- a/lucene/misc/src/java-module/module-info.java
+++ b/lucene/misc/src/java-module/module-info.java
@@ -15,16 +15,15 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Index tools and other miscellaneous code */
+module org.apache.lucene.misc {
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
-  requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+
+  exports org.apache.lucene.misc;
+  exports org.apache.lucene.misc.document;
+  exports org.apache.lucene.misc.index;
+  exports org.apache.lucene.misc.search;
+  exports org.apache.lucene.misc.store;
+  exports org.apache.lucene.misc.util;
+  exports org.apache.lucene.misc.util.fst;
 }

--- a/lucene/monitor/src/java-module/module-info.java
+++ b/lucene/monitor/src/java-module/module-info.java
@@ -15,16 +15,11 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Reverse-search implementation for monitoring and classification */
+module org.apache.lucene.monitor {
   requires org.apache.lucene.core;
   requires org.apache.lucene.analysis.common;
-  requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+  requires org.apache.lucene.memory;
+
+  exports org.apache.lucene.monitor;
 }

--- a/lucene/queries/src/java-module/module-info.java
+++ b/lucene/queries/src/java-module/module-info.java
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Filters and Queries that add to core Lucene */
+module org.apache.lucene.queries {
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
-  requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+
+  exports org.apache.lucene.queries;
+  exports org.apache.lucene.queries.function;
+  exports org.apache.lucene.queries.function.docvalues;
+  exports org.apache.lucene.queries.function.valuesource;
+  exports org.apache.lucene.queries.intervals;
+  exports org.apache.lucene.queries.mlt;
+  exports org.apache.lucene.queries.payloads;
+  exports org.apache.lucene.queries.spans;
 }

--- a/lucene/queryparser/src/java-module/module-info.java
+++ b/lucene/queryparser/src/java-module/module-info.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Query parsers and parsing framework */
+module org.apache.lucene.queryparser {
+  requires java.xml;
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.queries;
+  requires org.apache.lucene.sandbox;
+
+  exports org.apache.lucene.queryparser.charstream;
+  exports org.apache.lucene.queryparser.classic;
+  exports org.apache.lucene.queryparser.complexPhrase;
+  exports org.apache.lucene.queryparser.ext;
+  exports org.apache.lucene.queryparser.flexible.core;
+  exports org.apache.lucene.queryparser.flexible.core.builders;
+  exports org.apache.lucene.queryparser.flexible.core.config;
+  exports org.apache.lucene.queryparser.flexible.core.messages;
+  exports org.apache.lucene.queryparser.flexible.core.nodes;
+  exports org.apache.lucene.queryparser.flexible.core.parser;
+  exports org.apache.lucene.queryparser.flexible.core.processors;
+  exports org.apache.lucene.queryparser.flexible.core.util;
+  exports org.apache.lucene.queryparser.flexible.messages;
+  exports org.apache.lucene.queryparser.flexible.precedence;
+  exports org.apache.lucene.queryparser.flexible.precedence.processors;
+  exports org.apache.lucene.queryparser.flexible.standard;
+  exports org.apache.lucene.queryparser.flexible.standard.builders;
+  exports org.apache.lucene.queryparser.flexible.standard.config;
+  exports org.apache.lucene.queryparser.flexible.standard.nodes;
+  exports org.apache.lucene.queryparser.flexible.standard.nodes.intervalfn;
+  exports org.apache.lucene.queryparser.flexible.standard.parser;
+  exports org.apache.lucene.queryparser.flexible.standard.processors;
+  exports org.apache.lucene.queryparser.simple;
+  exports org.apache.lucene.queryparser.surround.parser;
+  exports org.apache.lucene.queryparser.surround.query;
+  exports org.apache.lucene.queryparser.xml;
+  exports org.apache.lucene.queryparser.xml.builders;
+}

--- a/lucene/replicator/src/java-module/_module-info.java
+++ b/lucene/replicator/src/java-module/_module-info.java
@@ -15,16 +15,18 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Lucene index files replication utility */
+// @SuppressWarnings({"requires-automatic"})
+/*
+module org.apache.lucene.replicator {
+  requires javax.servlet.api;
+  requires org.apache.httpcomponents.httpclient;
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
-  requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+  requires org.apache.lucene.facet;
+
+  exports org.apache.lucene.replicator;
+  exports org.apache.lucene.replicator.http;
+  exports org.apache.lucene.replicator.nrt;
+
 }
+*/

--- a/lucene/sandbox/src/java-module/module-info.java
+++ b/lucene/sandbox/src/java-module/module-info.java
@@ -15,16 +15,17 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Various third party contributions and new ideas */
+module org.apache.lucene.sandbox {
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
   requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+
+  exports org.apache.lucene.payloads;
+  exports org.apache.lucene.sandbox.codecs.idversion;
+  exports org.apache.lucene.sandbox.document;
+  exports org.apache.lucene.sandbox.queries;
+  exports org.apache.lucene.sandbox.search;
+
+  provides org.apache.lucene.codecs.PostingsFormat with
+      org.apache.lucene.sandbox.codecs.idversion.IDVersionPostingsFormat;
 }

--- a/lucene/spatial-extras/src/java-module/_module-info.java
+++ b/lucene/spatial-extras/src/java-module/_module-info.java
@@ -15,16 +15,25 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Geospatial search */
+// @SuppressWarnings({"requires-automatic"})
+/*
+module org.apache.lucene.spatial_extras {
+  requires spatial4j;
+  requires s2.geometry.library.java;
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
-  requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+  requires org.apache.lucene.spatial3d;
+
+  exports org.apache.lucene.spatial;
+  exports org.apache.lucene.spatial.bbox;
+  exports org.apache.lucene.spatial.composite;
+  exports org.apache.lucene.spatial.prefix;
+  exports org.apache.lucene.spatial.prefix.tree;
+  exports org.apache.lucene.spatial.query;
+  exports org.apache.lucene.spatial.serialized;
+  exports org.apache.lucene.spatial.spatial4j;
+  exports org.apache.lucene.spatial.util;
+  exports org.apache.lucene.spatial.vector;
+
 }
+*/

--- a/lucene/spatial3d/src/java-module/module-info.java
+++ b/lucene/spatial3d/src/java-module/module-info.java
@@ -15,16 +15,10 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** 3D spatial planar geometry APIs */
+module org.apache.lucene.spatial3d {
   requires org.apache.lucene.core;
-  requires org.apache.lucene.analysis.common;
-  requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+
+  exports org.apache.lucene.spatial3d;
+  exports org.apache.lucene.spatial3d.geom;
 }

--- a/lucene/suggest/src/java-module/module-info.java
+++ b/lucene/suggest/src/java-module/module-info.java
@@ -15,16 +15,22 @@
  * limitations under the License.
  */
 
-/** Luke : Lucene toolbox project. */
-@SuppressWarnings({"requires-automatic"})
-module org.apache.lucene.luke {
-  requires java.desktop;
-  requires java.logging;
+/** Auto-suggest and Spellchecking support */
+module org.apache.lucene.suggest {
   requires org.apache.lucene.core;
   requires org.apache.lucene.analysis.common;
-  requires org.apache.lucene.queries;
-  requires org.apache.lucene.queryparser;
-  requires org.apache.lucene.misc;
-  requires org.apache.logging.log4j;
-  requires org.apache.logging.log4j.core;
+
+  exports org.apache.lucene.search.spell;
+  exports org.apache.lucene.search.suggest;
+  exports org.apache.lucene.search.suggest.analyzing;
+  exports org.apache.lucene.search.suggest.document;
+  exports org.apache.lucene.search.suggest.fst;
+  exports org.apache.lucene.search.suggest.tst;
+
+  provides org.apache.lucene.codecs.PostingsFormat with
+      org.apache.lucene.search.suggest.document.Completion50PostingsFormat,
+      org.apache.lucene.search.suggest.document.Completion84PostingsFormat,
+      org.apache.lucene.search.suggest.document.Completion90PostingsFormat;
+  provides org.apache.lucene.analysis.TokenFilterFactory with
+      org.apache.lucene.search.suggest.analyzing.SuggestStopFilterFactory;
 }


### PR DESCRIPTION
This tries to convert all automatic modules into explicitly modularized jars.

**module list**
- backward-codecs: OK
- benchmark: Excluded; this depends on lots of third party jars. Modularizing it would not be trivial to me.
- classification: OK
- codecs: OK
- demo: OK
- expressions: Disabled; details will be shown in comments.
- facet: OK
- grouping: OK
- highlighter: OK
- join: OK
- luke: OK ("requires" statements added)
- memory: OK
- misc: OK
- monitor: OK
- queries: OK
- queryparser: OK
- replicator: Disabled; details will be shown in comments.
- sandbox: OK
- spatial3d: OK
- spatial-extras: Disabled; details will be shown in comments.
- suggest: OK
- test-framework: Excluded; there are split packages.

**Test**
```
lucene $ ./gradlew -p lucene/distribution-tests/ test

> Task :randomizationInfo
Running tests with randomization seed: tests.seed=BB74BEEF93BD01B5

> Task :errorProneSkipped
WARNING: errorprone disabled (skipped on non-nightly runs)

> Task :lucene:distribution-tests:test
:lucene:distribution-tests:test (SUCCESS): 3 test(s)

BUILD SUCCESSFUL in 2s
```