### PR TITLE
Replace module path with classpath for JMS-unfriendly projects

### DIFF
--- a/gradle/java/javac.gradle
+++ b/gradle/java/javac.gradle
@@ -85,3 +85,23 @@ allprojects {
     }
   }
 }
+
+// Replace the module path with the classpath for modules that depends on third party libraries
+// that does not support JMS (unnamed jars) so that Gradle can look up the dependencies.
+// This should be a transitional method until the libraries support JMS with proper (manual or automatic) module names.
+configure(subprojects.findAll {it.path in [
+  ":lucene:analysis:morfologik",
+  ":lucene:expressions",
+  ":lucene:replicator",
+  ":lucene:spatial-extras"
+] }) {
+  plugins.withType(JavaPlugin) {
+    tasks.withType(JavaCompile) {
+      doFirst {
+        options.compilerArgs += [
+          "--module-path", classpath.asPath
+        ]
+      }
+    }
+  }
+}

--- a/lucene/analysis/morfologik/src/java-module/module-info.java
+++ b/lucene/analysis/morfologik/src/java-module/module-info.java
@@ -16,8 +16,7 @@
  */
 
 /** Analyzer for dictionary stemming, built-in Polish dictionary */
-// @SuppressWarnings({"requires-automatic"})
-/*
+@SuppressWarnings({"requires-automatic"})
 module org.apache.lucene.analysis.morfologik {
   requires morfologik.stemming;
   requires org.apache.lucene.core;
@@ -29,4 +28,3 @@ module org.apache.lucene.analysis.morfologik {
   provides org.apache.lucene.analysis.TokenFilterFactory with
       org.apache.lucene.analysis.morfologik.MorfologikFilterFactory;
 }
-*/

--- a/lucene/expressions/src/java-module/module-info.java
+++ b/lucene/expressions/src/java-module/module-info.java
@@ -15,26 +15,16 @@
  * limitations under the License.
  */
 
-apply plugin: 'java-library'
+@SuppressWarnings({"requires-automatic"})
+module org.apache.lucene.expressions {
+  requires org.objectweb.asm;
+  requires org.objectweb.asm.commons;
+  requires antlr4.runtime;
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.codecs;
 
-description = 'Dynamically computed values to sort/facet/search on based on a pluggable grammar'
+  exports org.apache.lucene.expressions;
+  exports org.apache.lucene.expressions.js;
 
-dependencies {
-  api project(':lucene:core')
-
-  implementation project(':lucene:codecs')
-
-  implementation 'org.antlr:antlr4-runtime'
-
-  // It is awkward that we force-omit the intermediate dependency here...
-  // The dependency chain is:
-  //   asm-commons -> asm-tree -> asm
-  // Should we really go through these hoops?
-  implementation 'org.ow2.asm:asm'
-  implementation('org.ow2.asm:asm-commons', {
-    // exclude group: "org.ow2.asm", module: "asm-tree"
-    // exclude group: "org.ow2.asm", module: "asm-analysis"
-  })
-
-  testImplementation project(':lucene:test-framework')
 }
+

--- a/lucene/replicator/src/java-module/module-info.java
+++ b/lucene/replicator/src/java-module/module-info.java
@@ -16,8 +16,7 @@
  */
 
 /** Lucene index files replication utility */
-// @SuppressWarnings({"requires-automatic"})
-/*
+@SuppressWarnings({"requires-automatic"})
 module org.apache.lucene.replicator {
   requires javax.servlet.api;
   requires org.apache.httpcomponents.httpclient;
@@ -29,4 +28,3 @@ module org.apache.lucene.replicator {
   exports org.apache.lucene.replicator.nrt;
 
 }
-*/

--- a/lucene/spatial-extras/src/java-module/module-info.java
+++ b/lucene/spatial-extras/src/java-module/module-info.java
@@ -16,9 +16,9 @@
  */
 
 /** Geospatial search */
-// @SuppressWarnings({"requires-automatic"})
-/*
+@SuppressWarnings({"requires-automatic"})
 module org.apache.lucene.spatial_extras {
+  requires java.logging;
   requires spatial4j;
   requires s2.geometry.library.java;
   requires org.apache.lucene.core;
@@ -36,4 +36,3 @@ module org.apache.lucene.spatial_extras {
   exports org.apache.lucene.spatial.vector;
 
 }
-*/


### PR DESCRIPTION
This enables module-info.java for JMS-unfriendly sub-projects by tweaking the compile-time module path.
- analysis/morfologik
- expressions
- replicator
- spatial-extras

A brief rationale in my mind is: for the time being we have to manage the gap between the two worlds - pre-JMS and post-JMS - and there is not likely to be a legal way to do so as far as I can see. Although this may look like a rough hack that messes up the boundary of two worlds, the intention is clear, and throwing away is easy once it is no longer needed (...I tried to find a way to tweak the module path in a more fine-grained manner, but I felt it could overcomplicate the situation). Also, I think this would work as a marker or warning for the JMS-incompatible modules in Lucene.

Note: `precommit` fails since versions.lock should be updated.
