### PR TITLE
Enable module-info for all java projects.

### DIFF
--- a/gradle/java/modules.gradle
+++ b/gradle/java/modules.gradle
@@ -23,7 +23,6 @@ import java.util.stream.Collectors
 allprojects {
   plugins.withType(JavaPlugin) {
     // TODO, NOCOMMIT: Experiment on the morfologik subproject only, for now.
-    if (project.path == ":lucene:analysis:morfologik") {
       // We won't be using gradle's built-in automatic module finder (because there is no way
       // to put non-modular JARs on classpath).
       java {
@@ -116,7 +115,6 @@ allprojects {
         return project.version.toString()
       })
     }
-  }
 
   // TODO: remove the hacks excluding java-module source folder from ecjLint and javadoc rendering.
 }

--- a/gradle/java/modules.gradle
+++ b/gradle/java/modules.gradle
@@ -22,7 +22,6 @@ import java.util.stream.Collectors
 
 allprojects {
   plugins.withType(JavaPlugin) {
-    // TODO, NOCOMMIT: Experiment on the morfologik subproject only, for now.
       // We won't be using gradle's built-in automatic module finder (because there is no way
       // to put non-modular JARs on classpath).
       java {

--- a/lucene/benchmark/src/java-module/module-info.java
+++ b/lucene/benchmark/src/java-module/module-info.java
@@ -1,0 +1,24 @@
+@SuppressWarnings({"requires-automatic"})
+module org.apache.lucene.benchmark {
+  requires java.xml;
+  requires org.apache.lucene.core;
+  requires org.apache.lucene.analysis.common;
+  requires org.apache.lucene.facet;
+  requires org.apache.lucene.highlighter;
+  requires org.apache.lucene.queries;
+  requires org.apache.lucene.queryparser;
+  requires org.apache.lucene.spatial_extras;
+  requires spatial4j;
+
+  exports org.apache.lucene.benchmark;
+  exports org.apache.lucene.benchmark.byTask;
+  exports org.apache.lucene.benchmark.byTask.feeds;
+  exports org.apache.lucene.benchmark.byTask.programmatic;
+  exports org.apache.lucene.benchmark.byTask.stats;
+  exports org.apache.lucene.benchmark.byTask.tasks;
+  exports org.apache.lucene.benchmark.byTask.utils;
+  exports org.apache.lucene.benchmark.quality;
+  exports org.apache.lucene.benchmark.quality.trec;
+  exports org.apache.lucene.benchmark.quality.utils;
+  exports org.apache.lucene.benchmark.utils;
+}

--- a/lucene/distribution-tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
+++ b/lucene/distribution-tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
@@ -228,10 +228,6 @@ public class TestModularLayer {
                             module.descriptor().name()))
                 .sorted())
         .containsExactly(
-            "AUTOMATIC  org.apache.lucene.benchmark",
-            "AUTOMATIC  org.apache.lucene.expressions",
-            "AUTOMATIC  org.apache.lucene.replicator",
-            "AUTOMATIC  org.apache.lucene.spatial_extras",
             "NAMED      org.apache.lucene.analysis.common",
             "NAMED      org.apache.lucene.analysis.icu",
             "NAMED      org.apache.lucene.analysis.kuromoji",
@@ -242,10 +238,12 @@ public class TestModularLayer {
             "NAMED      org.apache.lucene.analysis.smartcn",
             "NAMED      org.apache.lucene.analysis.stempel",
             "NAMED      org.apache.lucene.backward_codecs",
+            "NAMED      org.apache.lucene.benchmark",
             "NAMED      org.apache.lucene.classification",
             "NAMED      org.apache.lucene.codecs",
             "NAMED      org.apache.lucene.core",
             "NAMED      org.apache.lucene.demo",
+            "NAMED      org.apache.lucene.expressions",
             "NAMED      org.apache.lucene.facet",
             "NAMED      org.apache.lucene.grouping",
             "NAMED      org.apache.lucene.highlighter",
@@ -256,8 +254,10 @@ public class TestModularLayer {
             "NAMED      org.apache.lucene.monitor",
             "NAMED      org.apache.lucene.queries",
             "NAMED      org.apache.lucene.queryparser",
+            "NAMED      org.apache.lucene.replicator",
             "NAMED      org.apache.lucene.sandbox",
             "NAMED      org.apache.lucene.spatial3d",
+            "NAMED      org.apache.lucene.spatial_extras",
             "NAMED      org.apache.lucene.suggest");
   }
 }

--- a/lucene/expressions/build.gradle
+++ b/lucene/expressions/build.gradle
@@ -26,15 +26,8 @@ dependencies {
 
   implementation 'org.antlr:antlr4-runtime'
 
-  // It is awkward that we force-omit the intermediate dependency here...
-  // The dependency chain is:
-  //   asm-commons -> asm-tree -> asm
-  // Should we really go through these hoops?
   implementation 'org.ow2.asm:asm'
-  implementation('org.ow2.asm:asm-commons', {
-    exclude group: "org.ow2.asm", module: "asm-tree"
-    exclude group: "org.ow2.asm", module: "asm-analysis"
-  })
+  implementation('org.ow2.asm:asm-commons')
 
   testImplementation project(':lucene:test-framework')
 }

--- a/lucene/expressions/src/java-module/module-info.java
+++ b/lucene/expressions/src/java-module/module-info.java
@@ -15,25 +15,14 @@
  * limitations under the License.
  */
 
-/** Geospatial search */
-// @SuppressWarnings({"requires-automatic"})
-/*
-module org.apache.lucene.spatial_extras {
-  requires spatial4j;
-  requires s2.geometry.library.java;
+@SuppressWarnings({"requires-automatic"})
+module org.apache.lucene.expressions {
+  requires org.objectweb.asm;
+  requires org.objectweb.asm.commons;
+  requires antlr4.runtime;
   requires org.apache.lucene.core;
-  requires org.apache.lucene.spatial3d;
+  requires org.apache.lucene.codecs;
 
-  exports org.apache.lucene.spatial;
-  exports org.apache.lucene.spatial.bbox;
-  exports org.apache.lucene.spatial.composite;
-  exports org.apache.lucene.spatial.prefix;
-  exports org.apache.lucene.spatial.prefix.tree;
-  exports org.apache.lucene.spatial.query;
-  exports org.apache.lucene.spatial.serialized;
-  exports org.apache.lucene.spatial.spatial4j;
-  exports org.apache.lucene.spatial.util;
-  exports org.apache.lucene.spatial.vector;
-
+  exports org.apache.lucene.expressions;
+  exports org.apache.lucene.expressions.js;
 }
-*/

--- a/lucene/replicator/src/java-module/module-info.java
+++ b/lucene/replicator/src/java-module/module-info.java
@@ -16,8 +16,7 @@
  */
 
 /** Lucene index files replication utility */
-// @SuppressWarnings({"requires-automatic"})
-/*
+@SuppressWarnings({"requires-automatic"})
 module org.apache.lucene.replicator {
   requires javax.servlet.api;
   requires org.apache.httpcomponents.httpclient;
@@ -27,6 +26,4 @@ module org.apache.lucene.replicator {
   exports org.apache.lucene.replicator;
   exports org.apache.lucene.replicator.http;
   exports org.apache.lucene.replicator.nrt;
-
 }
-*/

--- a/lucene/spatial-extras/src/java-module/module-info.java
+++ b/lucene/spatial-extras/src/java-module/module-info.java
@@ -15,17 +15,23 @@
  * limitations under the License.
  */
 
-// @SuppressWarnings({"requires-automatic"})
-/*
-module org.apache.lucene.expressions {
-  requires org.objectweb.asm;
-  requires org.objectweb.asm.commons;
-  requires antlr4.runtime;
+/** Geospatial search */
+@SuppressWarnings({"requires-automatic"})
+module org.apache.lucene.spatial_extras {
+  requires java.logging;
+  requires spatial4j;
+  requires s2.geometry.library.java;
   requires org.apache.lucene.core;
-  requires org.apache.lucene.codecs;
+  requires org.apache.lucene.spatial3d;
 
-  exports org.apache.lucene.expressions;
-  exports org.apache.lucene.expressions.js;
-
+  exports org.apache.lucene.spatial;
+  exports org.apache.lucene.spatial.bbox;
+  exports org.apache.lucene.spatial.composite;
+  exports org.apache.lucene.spatial.prefix;
+  exports org.apache.lucene.spatial.prefix.tree;
+  exports org.apache.lucene.spatial.query;
+  exports org.apache.lucene.spatial.serialized;
+  exports org.apache.lucene.spatial.spatial4j;
+  exports org.apache.lucene.spatial.util;
+  exports org.apache.lucene.spatial.vector;
 }
-*/


### PR DESCRIPTION
I confirmed that with https://github.com/apache/lucene/pull/470/commits/230d5c0d5afbd66564b39681268f9411df2b432f all java projects (except for ~"benchmark"~ and "test-framework") are successfully compiled with the module descriptor. Then - would it be good to enable module-info.java for all projects from now (to monitor if any problems pop up)?

Also, this removes "exclude" dependencies in "lucene/expressions" module, since they are incompatible with transitive dependencies defined in "asm-commons" module and we will need to remove it at some point anyway. 
```
lucene $ jar --describe-module --file ~/.gradle/caches/modules-2/files-2.1/org.ow2.asm/asm-commons/7.2/ca2954e8d92a05bacc28ff465b25c70e0f512497/asm-commons-7.2.jar 
org.objectweb.asm.commons@7.2.0 jar:file:///home/moco/.gradle/caches/modules-2/files-2.1/org.ow2.asm/asm-commons/7.2/ca2954e8d92a05bacc28ff465b25c70e0f512497/asm-commons-7.2.jar/!module-info.class open
exports org.objectweb.asm.commons
requires java.base mandated
requires org.objectweb.asm transitive
requires org.objectweb.asm.tree transitive
requires org.objectweb.asm.tree.analysis transitive
```