### PR TITLE
(NOCOMMIT) Add fake module descriptors for lucene/expressions runtime dependency

### DIFF
--- a/lucene/expressions/build.gradle
+++ b/lucene/expressions/build.gradle
@@ -21,9 +21,6 @@ description = 'Dynamically computed values to sort/facet/search on based on a pl
 
 dependencies {
   moduleApi project(':lucene:core')
-  // NOCOMMIT
-  moduleApi project(':lucene:fake:asm-tree')
-  moduleApi project(':lucene:fake:asm-analysis')
 
   moduleImplementation project(':lucene:codecs')
 
@@ -35,6 +32,9 @@ dependencies {
     exclude group: "org.ow2.asm", module: "asm-tree"
     exclude group: "org.ow2.asm", module: "asm-analysis"
   })
+  // NOCOMMIT
+  moduleImplementation project(':lucene:fake:asm-tree')
+  moduleImplementation project(':lucene:fake:asm-analysis')
 
   testImplementation project(':lucene:test-framework')
 }

--- a/lucene/expressions/build.gradle
+++ b/lucene/expressions/build.gradle
@@ -21,13 +21,20 @@ description = 'Dynamically computed values to sort/facet/search on based on a pl
 
 dependencies {
   moduleApi project(':lucene:core')
+  // NOCOMMIT
+  moduleApi project(':lucene:fake:asm-tree')
+  moduleApi project(':lucene:fake:asm-analysis')
 
   moduleImplementation project(':lucene:codecs')
 
   moduleImplementation 'org.antlr:antlr4-runtime'
 
   moduleImplementation 'org.ow2.asm:asm'
-  moduleImplementation 'org.ow2.asm:asm-commons'
+  //moduleImplementation 'org.ow2.asm:asm-commons'
+  moduleImplementation('org.ow2.asm:asm-commons', {
+    exclude group: "org.ow2.asm", module: "asm-tree"
+    exclude group: "org.ow2.asm", module: "asm-analysis"
+  })
 
   testImplementation project(':lucene:test-framework')
 }

--- a/lucene/fake/asm-analysis/build.gradle
+++ b/lucene/fake/asm-analysis/build.gradle
@@ -1,0 +1,3 @@
+apply plugin: 'java-library'
+
+description = 'Fake project emulating asm-analysis'

--- a/lucene/fake/asm-analysis/src/java-module/module-info.java
+++ b/lucene/fake/asm-analysis/src/java-module/module-info.java
@@ -1,0 +1,3 @@
+module org.objectweb.asm.tree.analysis {
+  // empty module discriptor
+}

--- a/lucene/fake/asm-tree/build.gradle
+++ b/lucene/fake/asm-tree/build.gradle
@@ -1,0 +1,3 @@
+apply plugin: 'java-library'
+
+description = 'Fake project emulating asm-tree'

--- a/lucene/fake/asm-tree/src/java-module/module-info.java
+++ b/lucene/fake/asm-tree/src/java-module/module-info.java
@@ -1,0 +1,3 @@
+module org.objectweb.asm.tree {
+  // empty module discriptor
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -63,3 +63,7 @@ include "lucene:test-framework"
 include "lucene:documentation"
 include "lucene:distribution"
 include "lucene:distribution-tests"
+
+// NOCOMMIT
+include "lucene:fake:asm-tree"
+include "lucene:fake:asm-analysis"


### PR DESCRIPTION
Perhaps it may be the easiest way (to me) if we want to minimize runtime dependencies for lucene/expressions.
(It is certainly possible and seems to be easy..., I am not fully sure faking the module descriptor is a sensible workaround or not.)

```
lucene $ ./gradlew -p lucene/fake/asm-tree/ jar
BUILD SUCCESSFUL in 1s

lucene $ jar --describe-module --file lucene/fake/asm-tree/build/libs/lucene-fake-asm-tree-10.0.0-SNAPSHOT.jar 
org.objectweb.asm.tree@10.0.0-SNAPSHOT jar:file:///mnt/hdd/repo/lucene/lucene/fake/asm-tree/build/libs/lucene-fake-asm-tree-10.0.0-SNAPSHOT.jar/!module-info.class
requires java.base mandated
```

```
lucene $ ./gradlew -p lucene/fake/asm-analysis/ jar
BUILD SUCCESSFUL in 1s

lucene $ jar --describe-module --file lucene/fake/asm-analysis/build/libs/lucene-fake-asm-analysis-10.0.0-SNAPSHOT.jar 
org.objectweb.asm.tree.analysis@10.0.0-SNAPSHOT jar:file:///mnt/hdd/repo/lucene/lucene/fake/asm-analysis/build/libs/lucene-fake-asm-analysis-10.0.0-SNAPSHOT.jar/!module-info.class
requires java.base mandated
```

```
lucene $ ./gradlew -p lucene/expressions/ jar
BUILD SUCCESSFUL in 7s

lucene $ jar --describe-module --file lucene/expressions/build/libs/lucene-expressions-10.0.0-SNAPSHOT.jar 
org.apache.lucene.expressions@10.0.0-SNAPSHOT jar:file:///mnt/hdd/repo/lucene/lucene/expressions/build/libs/lucene-expressions-10.0.0-SNAPSHOT.jar/!module-info.class
exports org.apache.lucene.expressions
exports org.apache.lucene.expressions.js
requires antlr4.runtime
requires java.base mandated
requires org.apache.lucene.codecs
requires org.apache.lucene.core
requires org.objectweb.asm
requires org.objectweb.asm.commons
```

