### PR TITLE
remove obsolete add-module option from luke start scripts

### DIFF
--- a/lucene/distribution/src/binary-release/bin/luke.cmd
+++ b/lucene/distribution/src/binary-release/bin/luke.cmd
@@ -17,5 +17,5 @@
 
 SETLOCAL
 SET MODULES=%~dp0..
-start javaw --module-path "%MODULES%\modules;%MODULES%\modules-thirdparty" --add-modules jdk.unsupported --module org.apache.lucene.luke
+start javaw --module-path "%MODULES%\modules;%MODULES%\modules-thirdparty" --module org.apache.lucene.luke
 ENDLOCAL

--- a/lucene/distribution/src/binary-release/bin/luke.sh
+++ b/lucene/distribution/src/binary-release/bin/luke.sh
@@ -17,4 +17,4 @@
 
 MODULES=`dirname "$0"`/..
 MODULES=`cd "$MODULES" && pwd`
-java --module-path "$MODULES/modules:$MODULES/modules-thirdparty" --add-modules jdk.unsupported --module org.apache.lucene.luke
+java --module-path "$MODULES/modules:$MODULES/modules-thirdparty" --module org.apache.lucene.luke

--- a/lucene/luke/src/java/org/apache/lucene/luke/util/LogRecordFormatter.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/util/LogRecordFormatter.java
@@ -25,6 +25,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.function.Function;
 
+/** Formats {@link CircularLogBufferHandler.ImmutableLogRecord} to string. */
 public class LogRecordFormatter
     implements Function<CircularLogBufferHandler.ImmutableLogRecord, String> {
   @Override


### PR DESCRIPTION
https://github.com/apache/lucene/pull/533#issuecomment-996742260

(This also includes the cherry-picked javadoc.)