### PR TITLE
Add a check that we can only call TestSecrets from the test framework

### DIFF
--- a/gradle/testing/randomization/policies/tests.policy
+++ b/gradle/testing/randomization/policies/tests.policy
@@ -57,8 +57,6 @@ grant {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed by cyberneko usage by benchmarks on J9
   permission java.lang.RuntimePermission "accessClassInPackage.org.apache.xerces.util";
-  // needed by org.apache.logging.log4j
-  permission java.lang.RuntimePermission "getenv.*";
   permission java.lang.RuntimePermission "getClassLoader";
   permission java.lang.RuntimePermission "setContextClassLoader";
 

--- a/gradle/testing/randomization/policies/tests.policy
+++ b/gradle/testing/randomization/policies/tests.policy
@@ -58,7 +58,6 @@ grant {
   // needed by cyberneko usage by benchmarks on J9
   permission java.lang.RuntimePermission "accessClassInPackage.org.apache.xerces.util";
   permission java.lang.RuntimePermission "getClassLoader";
-  permission java.lang.RuntimePermission "setContextClassLoader";
 
   // Needed for loading native library (lucene:misc:native) in lucene:misc
   permission java.lang.RuntimePermission "getFileStoreAttributes";

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -26,7 +26,8 @@ import org.apache.lucene.index.SegmentReader;
 
 /**
  * A set of static methods returning accessors for internal, package-private functionality in
- * Lucene.
+ * Lucene. All getters may only be called by the Lucene Test Framework module. Setters are
+ * initialized once on startup.
  */
 public final class TestSecrets {
   static {

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -45,7 +45,7 @@ public final class TestSecrets {
         };
 
     ensureInitialized.accept(ConcurrentMergeScheduler.class);
-    ensureInitialized.accept(SegmentReaderAccess.class);
+    ensureInitialized.accept(SegmentReader.class);
     ensureInitialized.accept(IndexWriter.class);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
@@ -22,9 +22,13 @@ public class TestTestSecrets extends LuceneTestCase {
 
   public void testCallerOfGetter() {
     final UnsupportedOperationException expected =
-        expectThrows(UnsupportedOperationException.class, () -> TestSecrets.getIndexWriterAccess());
+        expectThrows(UnsupportedOperationException.class, TestTestSecrets::illegalCaller);
     assertEquals(
         "Lucene TestSecrets can only be used by the test-framework.", expected.getMessage());
+  }
+
+  private static void illegalCaller() {
+    TestSecrets.getIndexWriterAccess();
   }
 
   public void testCannotSet() {

--- a/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
@@ -33,5 +33,8 @@ public class TestTestSecrets extends LuceneTestCase {
 
   public void testCannotSet() {
     expectThrows(AssertionError.class, () -> TestSecrets.setIndexWriterAccess(null));
+    expectThrows(AssertionError.class, () -> TestSecrets.setConcurrentMergeSchedulerAccess(null));
+    expectThrows(AssertionError.class, () -> TestSecrets.setIndexPackageAccess(null));
+    expectThrows(AssertionError.class, () -> TestSecrets.setSegmentReaderAccess(null));
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.internal.tests;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestTestSecrets extends LuceneTestCase {
+
+  public void testCallerOfGetter() {
+    final UnsupportedOperationException expected =
+        expectThrows(UnsupportedOperationException.class, () -> TestSecrets.getIndexWriterAccess());
+    assertEquals(
+        "Lucene TestSecrets can only be used by the test-framework.", expected.getMessage());
+  }
+
+  public void testCannotSet() {
+    expectThrows(AssertionError.class, () -> TestSecrets.setIndexWriterAccess(null));
+  }
+}


### PR DESCRIPTION
Here is my check caller change.

I also removed one obsolete policy only needed for log4j (now removed). I found this by accident.